### PR TITLE
speedtest: Switch CMD to ENTRYPOINT

### DIFF
--- a/speedtest/Dockerfile
+++ b/speedtest/Dockerfile
@@ -4,4 +4,4 @@ RUN git clone https://github.com/sivel/speedtest-cli.git /usr/src/speedtest-cli
 WORKDIR /usr/src/speedtest-cli
 RUN python setup.py install
 
-CMD ["speedtest-cli"]
+ENTRYPOINT ["speedtest-cli"]


### PR DESCRIPTION
Turns the docker image into more like an executable.

https://docs.docker.com/reference/builder/#entrypoint
