### PR TITLE
Replaced useradd with adduser

### DIFF
--- a/skype/Dockerfile
+++ b/skype/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:wheezy
 
-RUN useradd --create-home user
+RUN adduser user
 
 ENV SKYPE_URL http://download.skype.com/linux/skype-debian_4.3.0.37-1_i386.deb
 


### PR DESCRIPTION
from man:/useradd : 
useradd is a low level utility for adding users. On Debian, administrators should usually use adduser(8) instead.
