### PR TITLE
true: Update Makefile

### DIFF
--- a/true/Makefile
+++ b/true/Makefile
@@ -8,6 +8,8 @@ true-c: true.c
 true-go: true.go
 	go build -o $@ -ldflags -d $<
 
+.PHONY: all
 all: true-asm true-c true-go
+.PHONY: clean
 clean:
 	rm -f true-asm true-c true-go


### PR DESCRIPTION
"all" should be the default target; both "all" and "clean" should be phony.

BTW, the C and go binary can go smaller if you strip the symbols (`strip true-c`).