### PR TITLE
Fix code for sys_pause

### DIFF
--- a/sleeping-beauty/sleeping-beauty.asm
+++ b/sleeping-beauty/sleeping-beauty.asm
@@ -53,7 +53,7 @@ _start:
 
 do_pause:
 	; pause()
-	mov al, 29 ; sys_pause
+	mov al, 34 ; sys_pause
 	syscall
 
 	; tight loop because jpetazzo is trolling


### PR DESCRIPTION
On AMD64 the code for sys_pause is actually 34, see /usr/src/linux-headers-$(uname -r)/arch/x86/include/generated/asm/syscalls_64.h

(29 is sys_shmget, which BTW means that it fails with errno 38 (not implemented) and because there's a loop it ends up retrying the bad call and eating CPU cycles in the process)
