### PR TITLE
Modify PermitRootLogin in sshd_config

### DIFF
--- a/jenkins/slave/Dockerfile
+++ b/jenkins/slave/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add --update \
 	&& rm -rf /var/cache/apk/*
 
 RUN ssh-keygen -A
+RUN sed -i s/#PermitRootLogin.*/PermitRootLogin\ yes/ /etc/ssh/sshd_config
 RUN echo 'root:docker' | chpasswd
 
 # let's make /root a volume so ~/.ssh/authorized_keys is easier to save


### PR DESCRIPTION
I'm trying to use this jenkins-slave container but I can't ssh in with 'root:docker' if 'PermitRootLogin' is set to yes in sshd_config.

This PR should fix this problem. Thanks.