### PR TITLE
latex: added missing biber

### DIFF
--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -1,3 +1,3 @@
 FROM debian:jessie
 
-RUN apt-get update && apt-get install -y texlive-full
+RUN apt-get update && apt-get install -y texlive-full biber latexmk make


### PR DESCRIPTION
This fixes issue with missing `biber` in file processing:

```
Running 'biber  "master"'
------------
Latexmk: applying rule 'biber master'...
sh: 1: biber: not found
```
