### PR TITLE
Allow only 1 network which isn't /32

### DIFF
--- a/exim4/entrypoint.sh
+++ b/exim4/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 opts=(
 	dc_local_interfaces '0.0.0.0 ; ::0'
 	dc_other_hostnames ''
-	dc_relay_nets "$(ip addr show dev eth0 | awk '$1 == "inet" { print $2 }')"
+	dc_relay_nets "$(ip addr show dev eth0 | awk '$1 == "inet" { print $2 }' | grep -v \/32 | head -n1 )"
 )
 
 if [ "$GMAIL_USER" -a "$GMAIL_PASSWORD" ]; then


### PR DESCRIPTION
It doesn't work "AS IS" in the swarm, since there 2 networks. My change will ensure found network isn't /32 and will allow only 1st found. This way it works in swarm and uses correct network