### PR TITLE
Update speedtest-cli version

### DIFF
--- a/speedtest/Dockerfile
+++ b/speedtest/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.4
 
 RUN apk add --no-cache ca-certificates python3
 
-ENV SPEEDTEST_CLI_VERSION 0.3.4
+ENV SPEEDTEST_CLI_VERSION 1.0.2
 
 RUN pip3 install speedtest-cli==$SPEEDTEST_CLI_VERSION
 


### PR DESCRIPTION
This bumps the speedtest-cli version to the newest version on pip.