### PR TITLE
feat: allow multiple relay nets

### DIFF
--- a/exim4/entrypoint.sh
+++ b/exim4/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 opts=(
 	dc_local_interfaces '0.0.0.0 ; ::0'
 	dc_other_hostnames ''
-	dc_relay_nets "$(ip addr show dev eth0 | awk '$1 == "inet" { print $2 }' | tr '\n' ':' | rev | cut -c 2- | rev)"
+	dc_relay_nets "$(ip addr show dev eth0 | awk -v ORS=':' '$1 == "inet" { print $2 }' | rev | cut -c 2- | rev)"
 )
 
 if [ "$GMAIL_USER" -a "$GMAIL_PASSWORD" ]; then

--- a/exim4/entrypoint.sh
+++ b/exim4/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 opts=(
 	dc_local_interfaces '0.0.0.0 ; ::0'
 	dc_other_hostnames ''
-	dc_relay_nets "$(ip addr show dev eth0 | awk '$1 == "inet" { print $2 }')"
+	dc_relay_nets "$(ip addr show dev eth0 | awk '$1 == "inet" { print $2 }' | tr '\n' ':' | rev | cut -c 2- | rev)"
 )
 
 if [ "$GMAIL_USER" -a "$GMAIL_PASSWORD" ]; then


### PR DESCRIPTION
alternative to #35

This change allows exim4 to run with multiple relay nets, especially useful on docker swarm, else it will fail for ever :)
