### PR TITLE
Added stretch-backports source to get newest stable git

### DIFF
--- a/github-hub/Dockerfile
+++ b/github-hub/Dockerfile
@@ -5,9 +5,10 @@ RUN echo "deb http://ftp.debian.org/debian stretch-backports main" >> /etc/apt/s
 	&& apt-get install -y -t stretch-backports --no-install-recommends \
 		ca-certificates \
 		git \
+		less \
+		ssh \
 		vim-nox \
 		wget \
-		ssh \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV LANG C.UTF-8

--- a/github-hub/Dockerfile
+++ b/github-hub/Dockerfile
@@ -1,11 +1,13 @@
 FROM debian:stretch-slim
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN echo "deb http://ftp.debian.org/debian stretch-backports main" >> /etc/apt/sources.list \
+	&& apt-get update \
+	&& apt-get install -y -t stretch-backports --no-install-recommends \
 		ca-certificates \
 		git \
 		vim-nox \
 		wget \
+		ssh \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV LANG C.UTF-8


### PR DESCRIPTION
I have been using some git features like `include.path` and `includeif.gitdir` to separate my git config out into `.gitconfig`,`.gitconfig.alias`, `.gitconfig.personal`, and `.gitconfig.work` and using this to commit with the correct username and email for projects stored in `~/projects/work` and `~/projects/personal`. This has been around for a while but apparently only recently has started working with symlinked files (from my dotfiles directory into my home directory) and this require at least newer than the 2.11 that seems to be the latest on stretch or Ubuntu Xenial 16.04. I know symlinks don't really work very well inside Docker, but having the latest git and keeping it consistent between remote servers where I work with git and in this fantastic container feels sane. Outside of containers you have to use the git-core PPA or stretch-backports to get a newer stable version. I tested the version from stretch-backports in this container locally and it is working perfectly. It would also be perfectly acceptable if you want me to limit the backports install to only git, as I didn't test the versions of everything to see what all jumped before and after the new source.

Example gitconfig:

```
[push]
	default = simple
[color]
	ui = always
[core]
	excludesfile = ~/.gitignore.global
[include]
	path = ~/.gitconfig.alias
	path = ~/.gitconfig.personal
[includeIf "gitdir:~/projects/"]
	path = ~/.gitconfig.work
[includeIf "gitdir:~/projects/foss-projects/"]
	path = ~/.gitconfig.personal
```

I'm actually borrowing JessFraz's idea of using containers for everything, and the reason I added also ssh was to be able to push when using my `hub ()` Bash function aliased as `git` (the way God/defunkt/GitHub intended), otherwise there is a failure to fork an SSH process from inside the container (unless I also mapped in SSH from the host which seems like it might require a bunch more mappings).

```bash
# If you pre-create the ~/.config/hub file using the binary Docker works great, otherwise modifying it from the container makes it root owned and tends to fail
hub () {
    config_volumes=()
    for config in ~/.gitconfig*; do config_volumes+="-v ${HOME}/$(basename $config):/root/$(basename $config) "; done
    docker run -it --rm \
		${config_volumes[@]} \
		-v "${HOME}/.ssh/:/root/.ssh/" \
		-v "${HOME}/.config/hub:/root/.config/hub" \
		-v "$(pwd):/hub-workspace" \
		-w "/hub-workspace" \
		--entrypoint "hub" \
		--log-driver none \
		--name hub \
		tianon/github-hub "$@"
}
alias git='hub '
```

If I were going to really hot-dog it (grasping at straws may be a better term?), I would change the loop to `for config in ~/{.config/hub,.gitconfig*,.ssh};` to do all the volume mapping, but then my use of the `basename` would come back to bite me pretty hard.