### PR TITLE
exim4: add possibility to define a smtp relay

### DIFF
--- a/exim4/README.md
+++ b/exim4/README.md
@@ -16,3 +16,7 @@ Then `sendmail` in your linked container should work as expected.  You can also 
 ## Gmail
 
 If you'd rather not relay mail directly (which is a smart thing to not want to do generally), you can trivially configure this container to relay via a Gmail account instead!  Just add `-e GMAIL_USER=youruser@yourdomain.com -e GMAIL_PASSWORD=yourpasswordhere` and the entrypoint will automatically preconfigure to relay via the Gmail account specified!
+
+## Custom SMTP Smarthost
+
+If you don't want to relay from a Gmail account, you can define a SMTP relay server with `-e SMTP_RELAY=yourserver.yourdomain.com`. The entrypoint will preconfigure exim4-config too.

--- a/exim4/docker-entrypoint.sh
+++ b/exim4/docker-entrypoint.sh
@@ -3,28 +3,36 @@ set -e
 
 opts=(
 	dc_local_interfaces '0.0.0.0 ; ::0'
-	dc_other_hostnames ''
-	dc_relay_nets '0.0.0.0/0'
+        dc_other_hostnames ''
+        dc_relay_nets '0.0.0.0/0'
 )
 
 if [ "$GMAIL_USER" -a "$GMAIL_PASSWORD" ]; then
-	# see https://wiki.debian.org/GmailAndExim4
-	opts+=(
+        # see https://wiki.debian.org/GmailAndExim4
+        opts+=(
 		dc_eximconfig_configtype 'smarthost'
-		dc_smarthost 'smtp.gmail.com::587'
-	)
+                dc_smarthost 'smtp.gmail.com::587'
+        )
 	echo "*.google.com:$GMAIL_USER:$GMAIL_PASSWORD" > /etc/exim4/passwd.client
+
+elif [ "$SMTP_RELAY" ]; then
+        opts+=(
+                dc_eximconfig_configtype 'smarthost'
+                dc_smarthost "$SMTP_RELAY"
+        )
+
 else
 	opts+=(
 		dc_eximconfig_configtype 'internet'
-	)
+        )
 fi
 
 set-exim4-update-conf "${opts[@]}"
 
 if [ "$(id -u)" = '0' ]; then
-	mkdir -p /var/spool/exim4 /var/log/exim4 || :
-	chown -R Debian-exim:Debian-exim /var/spool/exim4 /var/log/exim4 || :
+        mkdir -p /var/spool/exim4 /var/log/exim4 || :
+        chown -R Debian-exim:Debian-exim /var/spool/exim4 /var/log/exim4 || :
 fi
 
 exec "$@"
+


### PR DESCRIPTION
For one use case, I needed to relay from another server. The only one provide here is only with Google.
Behind, Exim4 is using 2 variables : 
- dc_eximconfig_type
- dc_smarthost

Here I just add the possibility to define a custom url/server/dns plus to Gmail one with the envvar "SMTP_RELAY".