### PR TITLE
Add openssh client to GitHub hub

### DIFF
--- a/github-hub/Dockerfile
+++ b/github-hub/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		ca-certificates \
 		git \
+		openssh-client \
 		vim-nox \
 		wget \
 	&& rm -rf /var/lib/apt/lists/*

--- a/github-hub/Dockerfile
+++ b/github-hub/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG C.UTF-8
 WORKDIR /opt/hub
 ENV PATH /opt/hub/bin:$PATH
 
-ENV GITHUB_HUB_VERSION 2.2.9
+ENV GITHUB_HUB_VERSION 2.6.0
 
 RUN set -ex; \
 	\


### PR DESCRIPTION
Because `github-hub` docker image doesn't have openssh-client,
`git clone` (and allso pull, push) via ssh should fail.

```console
$ docker run tianon/github-hub:latest git clone git@github.com:okitan/dockerfiles.git
Cloning into 'dockerfiles'...
error: cannot run ssh: No such file or directory
fatal: unable to fork
```

I added openssh-client, and also updated `hub` to the latest version.

@tianon please review