### PR TITLE
Update backblaze-b2 to 1.4.0

### DIFF
--- a/backblaze-b2/Dockerfile
+++ b/backblaze-b2/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-alpine3.8
 
-ENV BACKBLAZE_B2_VERSION 1.3.6
+ENV BACKBLAZE_B2_VERSION 1.4.0
 
 RUN set -eux; \
 	pip install --no-cache-dir "b2 == $BACKBLAZE_B2_VERSION"


### PR DESCRIPTION
Updates backblaze-b2 to version 1.4.0.  Builds locally for me.