### PR TITLE
Move to buster-slim

### DIFF
--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 RUN apt-get update && apt-get install -y \
 		biber \


### PR DESCRIPTION
This uses TexLive 2018 instead of 2016.