### PR TITLE
Updated Gmail smtp host to smtp.gmail.com

### DIFF
--- a/exim4/docker-entrypoint.sh
+++ b/exim4/docker-entrypoint.sh
@@ -14,7 +14,7 @@ if [ "$1" = 'exim' ]; then
 			dc_eximconfig_configtype 'smarthost'
 			dc_smarthost 'smtp.gmail.com::587'
 		)
-		echo "*.google.com:$GMAIL_USER:$GMAIL_PASSWORD" > /etc/exim4/passwd.client
+		echo "smtp.gmail.com:$GMAIL_USER:$GMAIL_PASSWORD" > /etc/exim4/passwd.client
 	else
 		opts+=(
 			dc_eximconfig_configtype 'internet'


### PR DESCRIPTION
Updated Gmail smtp host to smtp.gmail.com
 https://support.google.com/mail/thread/16940173?hl=en