### PR TITLE
[exim4] Use exim4.conf.localmacros for the macroses

### DIFF
--- a/exim4/Dockerfile
+++ b/exim4/Dockerfile
@@ -34,7 +34,7 @@ RUN set -eux; \
 # https://blog.dhampir.no/content/exim4-line-length-in-debian-stretch-mail-delivery-failed-returning-message-to-sender
 # https://serverfault.com/a/881197
 # https://bugs.debian.org/828801
-RUN echo "IGNORE_SMTP_LINE_LENGTH_LIMIT='true'" >> /etc/exim4/update-exim4.conf.conf
+RUN echo "IGNORE_SMTP_LINE_LENGTH_LIMIT='true'" >> /etc/exim4/exim4.conf.localmacros
 
 RUN set -eux; \
 	mkdir -p /var/spool/exim4 /var/log/exim4; \


### PR DESCRIPTION
Adding macroses to the `update-exim4.conf.conf` causes warning:
```
undocumented line IGNORE_SMTP_LINE_LENGTH_LIMIT=1 found in /etc/exim4/update-exim4.conf.conf, generating exim macro
```

during the `update-exim4.conf` call.

According to the `Using Exim Macros to control the configuration` section of readme file of exim4-base:
>  For a non-split configuration, /etc/exim4/exim4.conf.localmacros gets read before /etc/exim4/exim4.conf.template. 
