### PR TITLE
Update to toybox 0.8.6

### DIFF
--- a/toybox/Dockerfile
+++ b/toybox/Dockerfile
@@ -23,8 +23,12 @@ RUN set -eux; \
 	tar -xf toybox.tgz --strip-components=1; \
 	rm toybox.tgz
 
-# Workaround for bug in scripts/mkroot.sh that exits 1 when BUILTIN=1
-RUN sed -i '273,275d' scripts/mkroot.sh
+# workaround for bug in scripts/mkroot.sh that exits 1 when BUILTIN=1; https://github.com/landley/toybox/issues/305
+RUN set -eux; \
+	wget -O builtin-fix.patch 'https://github.com/landley/toybox/commit/ea4748a7cbfa5e2f3ef188f917d4e5aeac70dd0f.patch'; \
+	patch -p1 --input=builtin-fix.patch; \
+	rm builtin-fix.patch
+
 RUN make root BUILTIN=1
 # (we set "BUILTIN=1" to avoid cpio / initramfs creation because we aren't building / don't need a kernel)
 

--- a/toybox/Dockerfile
+++ b/toybox/Dockerfile
@@ -16,13 +16,15 @@ WORKDIR /toybox
 
 # https://landley.net/toybox/downloads/?C=M;O=D
 # https://github.com/landley/toybox/releases
-ENV TOYBOX_VERSION 0.8.5
+ENV TOYBOX_VERSION 0.8.6
 
 RUN set -eux; \
 	wget -O toybox.tgz "https://landley.net/toybox/downloads/toybox-$TOYBOX_VERSION.tar.gz"; \
 	tar -xf toybox.tgz --strip-components=1; \
 	rm toybox.tgz
 
+# Workaround for bug in scripts/mkroot.sh that exits 1 when BUILTIN=1
+RUN sed -i '273,275d' scripts/mkroot.sh
 RUN make root BUILTIN=1
 # (we set "BUILTIN=1" to avoid cpio / initramfs creation because we aren't building / don't need a kernel)
 

--- a/toybox/Dockerfile
+++ b/toybox/Dockerfile
@@ -10,6 +10,7 @@ RUN set -eux; \
 		linux-headers \
 		make \
 		musl-dev \
+		patch \
 	;
 
 WORKDIR /toybox


### PR DESCRIPTION
Had to add a workaround to get the update to build - in this version `mkroot.sh` always exits 1 when BUILTIN=1 is set, causing the dockerfile to fail (will report this to the mailing list momentarily).