### PR TITLE
Update docker-master, especially with explicit "go X.YY" directive in our fake go.mod files

### DIFF
--- a/docker-master/Dockerfile
+++ b/docker-master/Dockerfile
@@ -44,7 +44,7 @@ RUN set -ex; \
 
 RUN set -eux; \
 	cd cli; \
-	echo 'module github.com/docker/cli' > go.mod; \
+	{ echo 'module github.com/docker/cli'; echo 'go 1.18'; } > go.mod; \
 # "go: inconsistent vendoring in /moby/cli:" -> "X@vY: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod"
 	rm vendor/modules.txt; \
 # can't use the Makefile anymore thanks to https://github.com/docker/cli/pull/2993 ...
@@ -53,7 +53,7 @@ RUN set -eux; \
 	docker --version; \
 	ldd /usr/local/bin/docker || :
 
-ENV MOBY_GITCOMMIT 9e7ed25c64607c5008270858ca5d0e947f34e68a
+ENV MOBY_GITCOMMIT 36a2dd36a078685c9f9c7ef7c5828ed382921ce9
 
 RUN set -ex; \
 	mkdir engine; \
@@ -80,7 +80,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 	cd engine; \
-	echo 'module github.com/docker/docker' > go.mod; \
+	{ echo 'module github.com/docker/docker'; echo 'go 1.18'; } > go.mod; \
 # fix "inconsistent vendoring" issue
 	rm vendor/modules.txt; \
 	sed -ri '/^[[:space:]]*copy_binaries /d' hack/make/binary-daemon; \

--- a/docker-master/Dockerfile.template
+++ b/docker-master/Dockerfile.template
@@ -4,7 +4,8 @@
 #
 #   $ docker run -d --name dind --privileged --volume dind:/var/lib/docker tianon/docker-master
 
-FROM golang:1.18-bullseye AS build
+{{ def gover: "1.18" -}}
+FROM golang:{{ gover }}-bullseye AS build
 
 RUN set -ex; \
 	apt-get update; \
@@ -38,7 +39,7 @@ RUN set -ex; \
 
 RUN set -eux; \
 	cd cli; \
-	echo 'module github.com/docker/cli' > go.mod; \
+	{ echo 'module github.com/docker/cli'; echo {{ "go " + gover | @sh }}; } > go.mod; \
 # "go: inconsistent vendoring in /moby/cli:" -> "X@vY: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod"
 	rm vendor/modules.txt; \
 # can't use the Makefile anymore thanks to https://github.com/docker/cli/pull/2993 ...
@@ -74,7 +75,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 	cd engine; \
-	echo 'module github.com/docker/docker' > go.mod; \
+	{ echo 'module github.com/docker/docker'; echo {{ "go " + gover | @sh }}; } > go.mod; \
 # fix "inconsistent vendoring" issue
 	rm vendor/modules.txt; \
 	sed -ri '/^[[:space:]]*copy_binaries /d' hack/make/binary-daemon; \

--- a/docker-master/versions.json
+++ b/docker-master/versions.json
@@ -2,5 +2,5 @@
   "cli": {
     "version": "ab794859fe792cc4b6d1632b919b775613bc17fc"
   },
-  "version": "9e7ed25c64607c5008270858ca5d0e947f34e68a"
+  "version": "36a2dd36a078685c9f9c7ef7c5828ed382921ce9"
 }


### PR DESCRIPTION
    # github.com/docker/docker/daemon
    daemon/daemon.go:109:36: type instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
    daemon/daemon.go:110:36: type instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
    daemon/daemon.go:111:36: type instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
    daemon/daemon.go:112:36: type instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)