### PR TITLE
Add test for buildkit image to make sure it works with buildx

### DIFF
--- a/.test/config.sh
+++ b/.test/config.sh
@@ -11,6 +11,9 @@ imageTests+=(
 	[tianon/infosiftr-moby]='c8dind'
 	[infosiftr/moby]='c8dind'
 
+	# make sure our buildkit image works correctly with buildx
+	[tianon/buildkit]='buildkitd'
+
 	# avoid: java.lang.UnsatisfiedLinkError: /opt/java/openjdk/lib/libfontmanager.so: libfreetype.so.6: cannot open shared object file: No such file or directory
 	[tianon/jenkins]='java-uimanager-font'
 )

--- a/.test/tests/buildkitd/run.sh
+++ b/.test/tests/buildkitd/run.sh
@@ -16,6 +16,8 @@ config='
 		gc = false
 '
 
+image="$(docker image inspect --format '{{ .ID }}' "$image")"
+
 args=(
 	--name "$builderName"
 	--node "$builderName"

--- a/.test/tests/buildkitd/run.sh
+++ b/.test/tests/buildkitd/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+image="$1"
+
+# mimic https://github.com/docker-library/official-images/blob/09efb10abd3214d02ad9a502b7358797acf486a8/.bin/docker-buildx-ensure.sh (since it's the user of tianon/buildkit)
+
+builderName='tianon-test-buildkit'
+trap 'docker buildx rm --force "$builderName" || :' EXIT
+
+config='
+	# https://github.com/moby/buildkit/blob/v0.11.4/docs/buildkitd.toml.md
+	[worker.oci]
+		gc = false
+	[worker.containerd]
+		gc = false
+'
+
+args=(
+	--name "$builderName"
+	--node "$builderName"
+	--driver docker-container
+	--driver-opt image="$image"
+	--bootstrap
+)
+docker buildx create "${args[@]}" --config <(printf '%s' "$config")
+
+docker buildx build --builder "$builderName" --load --tag "$builderName" - <<<'FROM hello-world'
+docker run --rm "$builderName"
+docker rmi "$builderName"

--- a/buildkit/buildkitd-entrypoint.sh
+++ b/buildkit/buildkitd-entrypoint.sh
@@ -5,8 +5,4 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	set -- buildkitd "$@"
 fi
 
-if [ "$1" = 'buildkitd' ]; then
-	set -- dind "$@"
-fi
-
 exec "$@"


### PR DESCRIPTION
This should help catch what prompted 2489257264631fb436d6c518c54a532e382e5218 / https://github.com/docker-library/official-images/pull/15815