### PR TITLE
Pin github-pages nokogiri version…

### DIFF
--- a/github-pages/Dockerfile
+++ b/github-pages/Dockerfile
@@ -7,6 +7,7 @@
 # https://pages.github.com/versions/
 FROM ruby:2.7-alpine3.16
 # https://www.ruby-lang.org/en/news/2023/03/30/ruby-2-7-8-released/
+# https://github.com/github/pages-gem/issues/752#issuecomment-1563750824 🙈
 
 ENV GITHUB_PAGES_VERSION 228
 
@@ -18,6 +19,9 @@ RUN set -eux; \
 		g++ \
 		patch \
 	; \
+	\
+# The last version of nokogiri (>= 1.13.6, < 2.0) to support your Ruby & RubyGems was 1.15.5. Try installing it with `gem install nokogiri -v 1.15.5` and then running the current command again 🙃
+	gem install nokogiri -v '~> 1.15.4'; \
 	\
 	gem install github-pages -v "$GITHUB_PAGES_VERSION"; \
 	\

--- a/github-pages/Dockerfile.template
+++ b/github-pages/Dockerfile.template
@@ -1,6 +1,7 @@
 # https://pages.github.com/versions/
 FROM ruby:{{ .ruby.version }}-alpine3.16
 # https://www.ruby-lang.org/en/news/2023/03/30/ruby-2-7-8-released/
+# https://github.com/github/pages-gem/issues/752#issuecomment-1563750824 🙈
 
 ENV GITHUB_PAGES_VERSION {{ .version }}
 
@@ -12,6 +13,9 @@ RUN set -eux; \
 		g++ \
 		patch \
 	; \
+	\
+# The last version of nokogiri (>= 1.13.6, < 2.0) to support your Ruby & RubyGems was 1.15.5. Try installing it with `gem install nokogiri -v 1.15.5` and then running the current command again 🙃
+	gem install nokogiri -v {{ "~> \(.nokogiri.version)" | @sh }}; \
 	\
 	gem install github-pages -v "$GITHUB_PAGES_VERSION"; \
 	\

--- a/github-pages/versions.json
+++ b/github-pages/versions.json
@@ -2,5 +2,8 @@
   "version": "228",
   "ruby": {
     "version": "2.7"
+  },
+  "nokogiri": {
+    "version": "1.15.4"
   }
 }

--- a/github-pages/versions.sh
+++ b/github-pages/versions.sh
@@ -13,6 +13,9 @@ json="$(jq <<<"$json" -c '
 			.ruby
 			| capture("^(?<version>[0-9]+[.][0-9]+)[.]")
 		),
+		nokogiri: {
+			version: .nokogiri,
+		},
 	}
 ')"
 


### PR DESCRIPTION
… (using "twiddle-wakka"/"~>" so we get 1.15.5 instead of 1.15.4)

This works around our recent build failures.

Ultimately, it seems I'll have to just stop maintaining this image at some point (https://github.com/github/pages-gem/issues/752#issuecomment-1563750824) :disappointed:

(Everything I can find seems to suggest that users who care should start using Jekyll directly via GHA instead of relying on `github-pages` :disappointed:)