### PR TITLE
Update versions

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -15,7 +15,7 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # https://pkgs.tailscale.com/stable/#static
-ENV TAILSCALE_VERSION 1.58.0
+ENV TAILSCALE_VERSION 1.56.1
 
 RUN set -eux; \
 	dpkgArch="$(dpkg --print-architecture)"; \

--- a/tailscale/versions.json
+++ b/tailscale/versions.json
@@ -1,6 +1,6 @@
 {
-  "commit": "dfc5715d9473ad16b132d1b7f4d22e5a607202e1",
-  "ref": "refs/tags/v1.58.0^{}",
-  "tag": "v1.58.0",
-  "version": "1.58.0"
+  "commit": "f1ea3161a2a06ad6474a9ea919e91e9bd6062f84",
+  "ref": "refs/tags/v1.56.1^{}",
+  "tag": "v1.56.1",
+  "version": "1.56.1"
 }

--- a/weechat/Dockerfile
+++ b/weechat/Dockerfile
@@ -46,7 +46,7 @@ RUN set -eux; \
 
 # https://weechat.org/download/stable/
 # https://weechat.org/download/debian/active/#debian_bullseye
-ENV WEECHAT_VERSION 4.1.3-1
+ENV WEECHAT_VERSION 4.2.1-1
 
 RUN set -eux; \
 	apt-get update; \

--- a/weechat/versions.json
+++ b/weechat/versions.json
@@ -1,4 +1,4 @@
 {
-  "sha256": "10a38f5cb8be8d7af98e28dc6d29ceea78ed88c3cf24d4209bac86228f0ba9a9",
-  "version": "4.1.3-1"
+  "sha256": "a1205bfa8ef2c97d13fab73614eb59ca05afb42dd13e8aff5d5b077e0e779a87",
+  "version": "4.2.1-1"
 }


### PR DESCRIPTION
Oof: https://github.com/tailscale/tailscale/releases/tag/v1.58.0 (I kept thinking this was a bug in my script or a hiccup in the `wget` :facepalm:)
> NOTE 21-Jan-2024: rollout of 1.58.0 has been paused while we investigate reports of a problem in handling portmap responses.

