### PR TITLE
Update infosiftr-moby to 23.0.11, engine 23.0.11-2~deb12u0, container…

### DIFF
--- a/infosiftr-moby/Dockerfile
+++ b/infosiftr-moby/Dockerfile
@@ -23,16 +23,16 @@ RUN echo 'deb [ allow-insecure=yes trusted=yes ] https://apt.tianon.xyz/moby boo
 # TODO deb822
 
 # http://apt.tianon.xyz/moby/pool/bookworm/main/moby-engine/
-ENV MOBY_ENGINE_VERSION 20.10.27-2~deb12u0
+ENV MOBY_ENGINE_VERSION 23.0.11-2~deb12u0
 # http://apt.tianon.xyz/moby/pool/bookworm/main/moby-containerd/
-ENV MOBY_CONTAINERD_VERSION 1.6.28-1~deb12u0
+ENV MOBY_CONTAINERD_VERSION 1.6.32-1~deb12u0
 # http://apt.tianon.xyz/moby/pool/bookworm/main/moby-runc/
 ENV MOBY_RUNC_VERSION 1.1.12-1~deb12u0
 
 # http://apt.tianon.xyz/moby/pool/bookworm/main/moby-cli/
-ENV MOBY_CLI_VERSION 20.10.27-1~deb12u0
+ENV MOBY_CLI_VERSION 23.0.10-1~deb12u0
 # http://apt.tianon.xyz/moby/pool/bookworm/main/moby-buildx/
-ENV MOBY_BUILDX_VERSION 0.12.1-1~deb12u0
+ENV MOBY_BUILDX_VERSION 0.14.1-1~deb12u0
 
 RUN set -eux; \
 	\

--- a/infosiftr-moby/Dockerfile.unstable
+++ b/infosiftr-moby/Dockerfile.unstable
@@ -23,16 +23,16 @@ RUN echo 'deb [ allow-insecure=yes trusted=yes ] https://apt.tianon.xyz/moby uns
 # TODO deb822
 
 # http://apt.tianon.xyz/moby/pool/unstable/main/moby-engine/
-ENV MOBY_ENGINE_VERSION 20.10.27-2
+ENV MOBY_ENGINE_VERSION 23.0.11-2
 # http://apt.tianon.xyz/moby/pool/unstable/main/moby-containerd/
-ENV MOBY_CONTAINERD_VERSION 1.6.28-1
+ENV MOBY_CONTAINERD_VERSION 1.6.32-1
 # http://apt.tianon.xyz/moby/pool/unstable/main/moby-runc/
 ENV MOBY_RUNC_VERSION 1.1.12-1
 
 # http://apt.tianon.xyz/moby/pool/unstable/main/moby-cli/
-ENV MOBY_CLI_VERSION 20.10.27-1
+ENV MOBY_CLI_VERSION 23.0.10-1
 # http://apt.tianon.xyz/moby/pool/unstable/main/moby-buildx/
-ENV MOBY_BUILDX_VERSION 0.12.1-1
+ENV MOBY_BUILDX_VERSION 0.14.1-1
 
 RUN set -eux; \
 	\

--- a/infosiftr-moby/versions.json
+++ b/infosiftr-moby/versions.json
@@ -3,51 +3,51 @@
     "version": "bookworm"
   },
   "engine": {
-    "sha256": "8841e1a354d5e4de375d623ef0367154093ce20bebf9a4cb898cf748eb6e83a1",
-    "version": "20.10.27-2~deb12u0"
+    "sha256": "18c71d49a98eedd038dc10ecc5ea55bf9e1aa19be177b4aaebbd7d33fd9351f6",
+    "version": "23.0.11-2~deb12u0"
   },
   "containerd": {
-    "sha256": "4a53a4d365342dcf2549e190f812fc454921fbf87d256c489e2fd2bcdf705d37",
-    "version": "1.6.28-1~deb12u0"
+    "sha256": "2d042cd509bc311eefbe64c0b04be3bba6147879213356b7525b96ded42a5b7c",
+    "version": "1.6.32-1~deb12u0"
   },
   "runc": {
     "sha256": "5c00c17469da23e9436f4013a78564693b752655c38d46e2d41932fa3ed1f315",
     "version": "1.1.12-1~deb12u0"
   },
   "cli": {
-    "sha256": "4890d2824ab2dd5c640704f7fc01b1d26ac0dc40e8202ffe168599676f63365d",
-    "version": "20.10.27-1~deb12u0"
+    "sha256": "ab6f07dcb6be74a30609784995b5d658773f81c41a0743d0d947dab81ac72f39",
+    "version": "23.0.10-1~deb12u0"
   },
   "cli-plugin-buildx": {
-    "sha256": "f5b7dd3b0366c1dc75a849a48cfd765927b9517ed6d76a6ee365c55cf1e6386f",
-    "version": "0.12.1-1~deb12u0"
+    "sha256": "0755a1890a8de1ca6b78778d49e2aa2771051bb3a353ab4575b78eafa38023bb",
+    "version": "0.14.1-1~deb12u0"
   },
   "unstable": {
     "engine": {
-      "sha256": "4d4b0436804dbceab118d7201cf6e409850fad79997e2d177f1c4d16928a25ea",
-      "version": "20.10.27-2"
+      "sha256": "618ac8080a7259d5557a409d50d282e5eff3eceefaf020d56639f716f2fd622e",
+      "version": "23.0.11-2"
     },
     "containerd": {
-      "sha256": "c7badd041edeaab0aba071c9adac5641c91520aeb5b8108351a70faf2b62ac02",
-      "version": "1.6.28-1"
+      "sha256": "30092a077292f1ed6b98f8694fb61cf25b24a9b3c7825ef2282b9db66c3a1c66",
+      "version": "1.6.32-1"
     },
     "runc": {
       "sha256": "8b7088956964f59825e2f856cc58820a754886a17d42bea2be18b54803a18232",
       "version": "1.1.12-1"
     },
     "cli": {
-      "sha256": "dccb8f174af1673b19e7db750399a30ecb31a78c373dcd98d88b4342f909f81f",
-      "version": "20.10.27-1"
+      "sha256": "77afa3ac0d4442243c913916dd3751d67b4ae9c0f61ffde66c733f38dfb15153",
+      "version": "23.0.10-1"
     },
     "cli-plugin-buildx": {
-      "sha256": "a8ef5b7a9d91e21b45813cfc98048ee5d68b538d6efa69c502ee1a4592da1133",
-      "version": "0.12.1-1"
+      "sha256": "1c9106369fc44d8877ed344f7c65727992f878eb1952a100c9d3c3e9f670895d",
+      "version": "0.14.1-1"
     }
   },
   "dind": {
     "version": "65cfcc28ab37cb75e1560e4b4738719c07c6618e"
   },
-  "version": "20.10.27",
+  "version": "23.0.11",
   "variants": [
     "",
     "unstable"


### PR DESCRIPTION
…d 1.6.32-1~deb12u0, cli 23.0.10-1~deb12u0, cli-plugin-buildx 0.14.1-1~deb12u0, unstable engine 23.0.11-2, unstable containerd 1.6.32-1, unstable cli 23.0.10-1, unstable cli-plugin-buildx 0.14.1-1