### PR TITLE
Add hacky workarounds in infosiftr/moby to install libseccomp2 version 2.5.5 from unstable

### DIFF
--- a/infosiftr-moby/Dockerfile
+++ b/infosiftr-moby/Dockerfile
@@ -17,6 +17,21 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
+# see https://github.com/docker-library/official-images/issues/16830
+# esp. https://github.com/docker-library/official-images/issues/16830#issuecomment-2130971029
+# (TLDR: we need libseccomp2 version 2.5.5+ and stable as of 2024-05-25 only has 2.5.4; https://bugs.debian.org/1071822)
+RUN set -eux; \
+	v="$(dpkg-query --show --showformat '${Version}\n' libseccomp2)"; \
+	if dpkg --compare-versions "$v" '<<' '2.5.5~'; then \
+# TODO deb822
+		echo 'deb http://deb.debian.org/debian unstable main' > /etc/apt/sources.list.d/unstable.list; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends libseccomp2/unstable; \
+		rm -rf /etc/apt/sources.list.d/unstable.list /var/lib/apt/lists/*; \
+	fi; \
+	v="$(dpkg-query --show --showformat '${Version}\n' libseccomp2)"; \
+	dpkg --compare-versions "$v" '>=' '2.5.5~'
+
 # https://apt.tianon.xyz/moby
 # https://apt.tianon.xyz/moby/dists/bookworm/tianon-moby.sources
 RUN echo 'deb [ allow-insecure=yes trusted=yes ] https://apt.tianon.xyz/moby bookworm main' > /etc/apt/sources.list.d/moby.list

--- a/infosiftr-moby/Dockerfile.template
+++ b/infosiftr-moby/Dockerfile.template
@@ -12,6 +12,27 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
+# see https://github.com/docker-library/official-images/issues/16830
+# esp. https://github.com/docker-library/official-images/issues/16830#issuecomment-2130971029
+# (TLDR: we need libseccomp2 version 2.5.5+ and stable as of 2024-05-25 only has 2.5.4; https://bugs.debian.org/1071822)
+RUN set -eux; \
+{{ if debian != "unstable" then ( -}}
+	v="$(dpkg-query --show --showformat '${Version}\n' libseccomp2)"; \
+	if dpkg --compare-versions "$v" '<<' '2.5.5~'; then \
+# TODO deb822
+		echo 'deb http://deb.debian.org/debian unstable main' > /etc/apt/sources.list.d/unstable.list; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends libseccomp2/unstable; \
+		rm -rf /etc/apt/sources.list.d/unstable.list /var/lib/apt/lists/*; \
+	fi; \
+{{ ) else ( -}}
+	apt-get update; \
+	apt-get install -y --no-install-recommends libseccomp2; \
+	rm -rf /var/lib/apt/lists/*; \
+{{ ) end -}}
+	v="$(dpkg-query --show --showformat '${Version}\n' libseccomp2)"; \
+	dpkg --compare-versions "$v" '>=' '2.5.5~'
+
 # https://apt.tianon.xyz/moby
 # https://apt.tianon.xyz/moby/dists/{{ .debian.version }}/tianon-moby.sources
 RUN echo 'deb [ allow-insecure=yes trusted=yes ] https://apt.tianon.xyz/moby {{ debian }} main' > /etc/apt/sources.list.d/moby.list

--- a/infosiftr-moby/Dockerfile.unstable
+++ b/infosiftr-moby/Dockerfile.unstable
@@ -17,6 +17,16 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
+# see https://github.com/docker-library/official-images/issues/16830
+# esp. https://github.com/docker-library/official-images/issues/16830#issuecomment-2130971029
+# (TLDR: we need libseccomp2 version 2.5.5+ and stable as of 2024-05-25 only has 2.5.4; https://bugs.debian.org/1071822)
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends libseccomp2; \
+	rm -rf /var/lib/apt/lists/*; \
+	v="$(dpkg-query --show --showformat '${Version}\n' libseccomp2)"; \
+	dpkg --compare-versions "$v" '>=' '2.5.5~'
+
 # https://apt.tianon.xyz/moby
 # https://apt.tianon.xyz/moby/dists/bookworm/tianon-moby.sources
 RUN echo 'deb [ allow-insecure=yes trusted=yes ] https://apt.tianon.xyz/moby unstable main' > /etc/apt/sources.list.d/moby.list


### PR DESCRIPTION
Refs https://github.com/docker-library/official-images/issues/16830, especially https://github.com/docker-library/official-images/issues/16830#issuecomment-2130971029