### PR TITLE
Set better BuildKit version strings (even more obviously "tianon")

### DIFF
--- a/buildkit/Dockerfile
+++ b/buildkit/Dockerfile
@@ -39,8 +39,8 @@ RUN set -eux; \
 	pkg='github.com/moby/buildkit'; \
 	ldflags=" \
 		-d -w \
-		-X '$pkg/version.Version=$BUILDKIT_VERSION' \
-		-X '$pkg/version.Revision=tianon' \
+		-X '$pkg/version.Version=$BUILDKIT_VERSION-tianon' \
+		-X '$pkg/version.Revision=v$BUILDKIT_VERSION+tianon-patches' \
 		-X '$pkg/version.Package=$pkg' \
 	"; \
 	go build -o /buildkitd -trimpath -ldflags "$ldflags" ./cmd/buildkitd; \

--- a/buildkit/Dockerfile.template
+++ b/buildkit/Dockerfile.template
@@ -34,8 +34,8 @@ RUN set -eux; \
 	pkg='github.com/moby/buildkit'; \
 	ldflags=" \
 		-d -w \
-		-X '$pkg/version.Version=$BUILDKIT_VERSION' \
-		-X '$pkg/version.Revision=tianon' \
+		-X '$pkg/version.Version=$BUILDKIT_VERSION-tianon' \
+		-X '$pkg/version.Revision=v$BUILDKIT_VERSION+tianon-patches' \
 		-X '$pkg/version.Package=$pkg' \
 	"; \
 	go build -o /buildkitd -trimpath -ldflags "$ldflags" ./cmd/buildkitd; \


### PR DESCRIPTION
I thought "revision" was enough because it shows up in `buildkitd --version`, but `docker buildx ls` and `docker buildx inspect` only shows "version", so my "version" should include `tianon` (and I might as well make my "revision" more clearly denoting that I've patched the build).

https://github.com/tianon/dockerfiles/pull/721#issuecomment-2140962835