### PR TITLE
Backport upstream BuildKit commit for fetching commits on tags but not branches

### DIFF
--- a/buildkit/Dockerfile
+++ b/buildkit/Dockerfile
@@ -10,6 +10,7 @@ FROM --platform=$BUILDPLATFORM golang:1.21 AS build
 ENV BUILDKIT_VERSION 0.14.1
 
 COPY \
+	backport-5072-fetch-tags.patch \
 	containerd-arm64-v8.patch \
 	git-no-submodules.patch \
 	mips64le.patch \

--- a/buildkit/Dockerfile.template
+++ b/buildkit/Dockerfile.template
@@ -5,6 +5,7 @@ FROM --platform=$BUILDPLATFORM golang:{{ .go.version }} AS build
 ENV BUILDKIT_VERSION {{ .version }}
 
 COPY \
+	backport-5072-fetch-tags.patch \
 	containerd-arm64-v8.patch \
 	git-no-submodules.patch \
 	mips64le.patch \

--- a/buildkit/backport-5072-fetch-tags.patch
+++ b/buildkit/backport-5072-fetch-tags.patch
@@ -1,0 +1,16 @@
+Subject: git: fix pulling commit SHA only referenced from a tag
+Author: Tonis Tiigi <tonistiigi@gmail.com>
+Applied-Upstream: 0.15+; https://github.com/moby/buildkit/pull/5072
+
+diff --git a/source/git/source.go b/source/git/source.go
+index 998ede24ea4e..1b757500d7a3 100644
+--- a/source/git/source.go
++++ b/source/git/source.go
+@@ -470,6 +470,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out
+ 		if !isCommitSHA(ref) { // TODO: find a branch from ls-remote?
+ 			args = append(args, "--depth=1", "--no-tags")
+ 		} else {
++			args = append(args, "--tags")
+ 			if _, err := os.Lstat(filepath.Join(gitDir, "shallow")); err == nil {
+ 				args = append(args, "--unshallow")
+ 			}


### PR DESCRIPTION
- https://github.com/moby/buildkit/pull/5072

This will fix DOI issues building several Kong versions.

(If we either _also_ update to 0.14 _or_ I go build 0.13 again with this same backport :upside_down_face:)