### PR TITLE
Add multiple versions/variants of containerd (1.6 + pre-releases)

### DIFF
--- a/.test/config.sh
+++ b/.test/config.sh
@@ -6,7 +6,7 @@ imageTests+=(
 	[tianon/true]='true'
 
 	# run containerd test on containerd-containing images :D
-	[tianon/containerd:c8dind]='c8dind'
+	[tianon/containerd]='c8dind'
 	[tianon/docker-master]='c8dind'
 	[tianon/infosiftr-moby]='c8dind'
 	[infosiftr/moby]='c8dind'
@@ -24,9 +24,6 @@ globalExcludeTests+=(
 	[tianon/sleeping-beauty_utc]=1
 	[tianon/true_no-hard-coded-passwords]=1
 	[tianon/true_utc]=1
-
-	# needs --privileged (by design)
-	[tianon/containerd:c8dind_override-cmd]=1
 )
 
 # run Docker tests on Docker images :D

--- a/containerd/Dockerfile.1.6
+++ b/containerd/Dockerfile.1.6
@@ -42,15 +42,14 @@ RUN set -eux; \
 	runc --version
 
 # https://github.com/containerd/containerd/releases
-ENV CONTAINERD_VERSION 1.7.19
+ENV CONTAINERD_VERSION 1.6.33
 RUN set -eux; \
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
-		'amd64') url='https://github.com/containerd/containerd/releases/download/v1.7.19/containerd-1.7.19-linux-amd64.tar.gz'; sha256='97f75e60f0ad19d335b1d23385835df721cad4492740d50576997f2717dc3f94' ;; \
-		'arm64') url='https://github.com/containerd/containerd/releases/download/v1.7.19/containerd-1.7.19-linux-arm64.tar.gz'; sha256='1839e6f7cd7c62d9df3ef3deac3f404cdd5cd47bbdf8acfeb0b0f3776eb20002' ;; \
-		'ppc64el') url='https://github.com/containerd/containerd/releases/download/v1.7.19/containerd-1.7.19-linux-ppc64le.tar.gz'; sha256='f41c2f28ee933a9ca24ff02cca159099fbcf798850e56cf0b7a6047ebe21fa86' ;; \
-		'riscv64') url='https://github.com/containerd/containerd/releases/download/v1.7.19/containerd-1.7.19-linux-riscv64.tar.gz'; sha256='31f1b5593f3c35b7c4adeb4635269e6bf9b1d31526c7ed4a70ff1ad2abc2d98c' ;; \
-		's390x') url='https://github.com/containerd/containerd/releases/download/v1.7.19/containerd-1.7.19-linux-s390x.tar.gz'; sha256='66a41c2eeda1b5b355270bf9a9680f4955eefe1614bd08cca71c131394b6dc90' ;; \
+		'amd64') url='https://github.com/containerd/containerd/releases/download/v1.6.33/containerd-1.6.33-linux-amd64.tar.gz'; sha256='a0c7daa50386dc3ca19cbeb83d6987d43bdd92c0bb0429d08be7f9be4f9c307a' ;; \
+		'arm64') url='https://github.com/containerd/containerd/releases/download/v1.6.33/containerd-1.6.33-linux-arm64.tar.gz'; sha256='432cf17fbc01ba4fc59b949210baa96865185b8eb3b3292eb7a00e2f6bde9fe9' ;; \
+		'ppc64el') url='https://github.com/containerd/containerd/releases/download/v1.6.33/containerd-1.6.33-linux-ppc64le.tar.gz'; sha256='0a77fba37290a40a7853dbd7e5a297288d3657f7e92cd7864bc7187189a0a370' ;; \
+		'riscv64') url='https://github.com/containerd/containerd/releases/download/v1.6.33/containerd-1.6.33-linux-riscv64.tar.gz'; sha256='881e0013780a3a8cefd1fac39dcba771ed267f8f908ca8b2d628e6593b1de88c' ;; \
 		*) echo >&2 "error: unsupported architecture: '$dpkgArch'"; exit 1 ;; \
 	esac; \
 	wget -O containerd.tar.gz "$url" --progress=dot:giga; \

--- a/containerd/Dockerfile.c8dind
+++ b/containerd/Dockerfile.c8dind
@@ -1,3 +1,0 @@
-FROM tianon/containerd
-ENTRYPOINT ["dind", "docker-entrypoint.sh"]
-CMD ["containerd"]

--- a/containerd/Dockerfile.rc
+++ b/containerd/Dockerfile.rc
@@ -42,15 +42,15 @@ RUN set -eux; \
 	runc --version
 
 # https://github.com/containerd/containerd/releases
-ENV CONTAINERD_VERSION 1.7.19
+ENV CONTAINERD_VERSION 2.0.0-rc.3
 RUN set -eux; \
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
-		'amd64') url='https://github.com/containerd/containerd/releases/download/v1.7.19/containerd-1.7.19-linux-amd64.tar.gz'; sha256='97f75e60f0ad19d335b1d23385835df721cad4492740d50576997f2717dc3f94' ;; \
-		'arm64') url='https://github.com/containerd/containerd/releases/download/v1.7.19/containerd-1.7.19-linux-arm64.tar.gz'; sha256='1839e6f7cd7c62d9df3ef3deac3f404cdd5cd47bbdf8acfeb0b0f3776eb20002' ;; \
-		'ppc64el') url='https://github.com/containerd/containerd/releases/download/v1.7.19/containerd-1.7.19-linux-ppc64le.tar.gz'; sha256='f41c2f28ee933a9ca24ff02cca159099fbcf798850e56cf0b7a6047ebe21fa86' ;; \
-		'riscv64') url='https://github.com/containerd/containerd/releases/download/v1.7.19/containerd-1.7.19-linux-riscv64.tar.gz'; sha256='31f1b5593f3c35b7c4adeb4635269e6bf9b1d31526c7ed4a70ff1ad2abc2d98c' ;; \
-		's390x') url='https://github.com/containerd/containerd/releases/download/v1.7.19/containerd-1.7.19-linux-s390x.tar.gz'; sha256='66a41c2eeda1b5b355270bf9a9680f4955eefe1614bd08cca71c131394b6dc90' ;; \
+		'amd64') url='https://github.com/containerd/containerd/releases/download/v2.0.0-rc.3/containerd-2.0.0-rc.3-linux-amd64.tar.gz'; sha256='467e38c95c7d06cb22226d8dd8acbda1be9ff785266b626886433fe96dfcddfd' ;; \
+		'arm64') url='https://github.com/containerd/containerd/releases/download/v2.0.0-rc.3/containerd-2.0.0-rc.3-linux-arm64.tar.gz'; sha256='c351fe80f8da958f548a097a7c16a23df3a2939ea1fee0df7c02f6671d999939' ;; \
+		'ppc64el') url='https://github.com/containerd/containerd/releases/download/v2.0.0-rc.3/containerd-2.0.0-rc.3-linux-ppc64le.tar.gz'; sha256='96b3283829af68f2e1695663f8578f59022cbe3066091f2b9a90182949cc8313' ;; \
+		'riscv64') url='https://github.com/containerd/containerd/releases/download/v2.0.0-rc.3/containerd-2.0.0-rc.3-linux-riscv64.tar.gz'; sha256='4388487c199956e7343952f157461d01e5810bbf3f2d01a77df43b38029960e3' ;; \
+		's390x') url='https://github.com/containerd/containerd/releases/download/v2.0.0-rc.3/containerd-2.0.0-rc.3-linux-s390x.tar.gz'; sha256='be24f0f79c7c5e2a4aecee35facefaea6452359c0e94f4de771877fa3257802f' ;; \
 		*) echo >&2 "error: unsupported architecture: '$dpkgArch'"; exit 1 ;; \
 	esac; \
 	wget -O containerd.tar.gz "$url" --progress=dot:giga; \

--- a/containerd/Dockerfile.template
+++ b/containerd/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # runtime deps
 RUN set -eux; \
@@ -33,6 +33,7 @@ RUN set -eux; \
 	runc --version
 
 # https://github.com/containerd/containerd/releases
+{{ if env.variant != "" then .[env.variant] else . end | ( -}}
 ENV CONTAINERD_VERSION {{ .version }}
 RUN set -eux; \
 	dpkgArch="$(dpkg --print-architecture)"; \
@@ -47,6 +48,7 @@ RUN set -eux; \
 	tar -xvf containerd.tar.gz -C /usr/local/; \
 	rm containerd.tar.gz; \
 	containerd --version
+{{ ) -}}
 
 RUN set -eux; \
 	mkdir -p /run/containerd /var/lib/containerd; \
@@ -59,5 +61,5 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["containerd"]
 
-# use "docker run ... dind containerd" if you want to run real containers (with "--privileged")
-# see also Dockerfile.c8dind (or "tianon/containerd:c8dind")
+# the entrypoint will try to automatically determine intent based on uid/gid (and include the "dind" wrapper automatically)
+# if it does not, use "docker run ... dind containerd" if you want to run real containers (with "--privileged")

--- a/containerd/docker-entrypoint.sh
+++ b/containerd/docker-entrypoint.sh
@@ -7,24 +7,31 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 fi
 
 # if we're not root, let's adjust all the "uid" and "gid" parameters of the config to whatever our current user is (so we avoid "chown" permission errors)
-uid="$(id -u)"; gid="$(id -g)"
-if [ "$uid" != 0 ] && [ "$1" = 'containerd' ]; then
-	shift
+if [ "$1" = 'containerd' ]; then
+	uid="$(id -u)"
+	if [ "$uid" != 0 ]; then
+		shift
 
-	configDump=( containerd config dump )
-	if ! "${configDump[@]}" &> /dev/null; then
-		configDump=( containerd --config /dev/null config dump )
-		"${configDump[@]}" > /dev/null
-	fi
+		if ! configDump="$(containerd config dump 2>/dev/null)"; then
+			configDump="$(containerd --config /dev/null config dump)"
+		fi
 
-	exec containerd --config <(
-		"${configDump[@]}" \
-			| awk -v uid="$uid" -v gid="$gid" '
+		gid="$(id -g)"
+
+		exec containerd --config <(
+			awk <<<"$configDump" -v uid="$uid" -v gid="$gid" '
 				$1 == "uid" { gsub(/=.+$/, "= " uid) }
 				$1 == "gid" { gsub(/=.+$/, "= " gid) }
 				{ print }
 			'
-	) "$@"
+		) "$@"
+	fi
+
+	# we're root *and* running containerd, so let's do a few crude checks for whether the dind script has already run (or whether we should automatically run it)
+	if [ -z "${container:-}" ] && ! mountpoint -q /tmp; then
+		# TODO somehow also detect --privileged ?
+		set -- dind "$@"
+	fi
 fi
 
 exec "$@"

--- a/containerd/gsl.sh
+++ b/containerd/gsl.sh
@@ -5,28 +5,111 @@ cd "$(dirname "$BASH_SOURCE")"
 dir="$(basename "$PWD")"
 cd ..
 
-version="$(jq -r '.version' "$dir/versions.json")"
 from="$(awk '$1 == "FROM" { print $2; exit }' "$dir/Dockerfile")" # TODO multi-stage build??
-fromArches="$(bashbrew remote arches --json "$from" | jq -c '.arches | keys')"
-arches="$(jq -r -L "$dir/../.libs" --argjson fromArches "$fromArches" '
+fromArches="$(bashbrew remote arches --json "$from" | jq -r '.arches | keys')"
+
+commit="$(git -C "$dir" log -1 --format='format:%H' HEAD -- .)"
+
+export fromArches commit dir
+exec jq -r -L "$dir/../.libs" '
 	include "lib"
 	;
-	[
-		$fromArches,
-		(.arches | map_values(select(.dpkgArch)) | keys),
-		(.runc.arches | map_values(select(.dpkgArch)) | keys),
-		empty
+	(env.fromArches | fromjson) as $fromArches
+	| (
+		[
+			$fromArches,
+			(.runc.arches | map_values(select(.dpkgArch)) | keys),
+			empty
+		]
+		| intersection
+	) as $intArches
+	| [
+		{
+			Maintainers: "Tianon Gravi <tianon@tianon.xyz> (@tianon)",
+			GitRepo: "https://github.com/tianon/dockerfiles.git",
+			GitCommit: env.commit,
+			Directory: env.dir,
+		},
+		(
+			(
+				[
+					.variants[] as $variant
+					| {
+						key: $variant,
+						value: (
+							if $variant != "" then .[$variant] else . end
+							| {
+								variant: $variant,
+								version: .version,
+								arches: (
+									[
+										$intArches,
+										(.arches | map_values(select(.dpkgArch)) | keys),
+										empty
+									]
+									| intersection
+								),
+							}
+						),
+					}
+				]
+				| from_entries
+			)
+			| if (.rc.version | split(".-") | tonumber? // .) <= (.[""].version | split(".-") | tonumber? // .) then
+				# if the RC is not newer than the current stable, skip it
+				del(.rc)
+			else . end
+			| map(
+				.variant as $variant
+				| {
+					Tags: (
+						.version as $version
+						| if $variant == "dev" then
+							[]
+						else
+							$version
+							| [ scan("(?:[.-]+|^)[^.-]*") ]
+							| reduce .[] as $p ([];
+								if length > 0 then
+									[ .[0] + $p, .[] ]
+								else [ $p ] end
+							)
+						end
+						| . + [
+							if $variant == "" then
+								"latest"
+							elif index($variant) | not then
+								$variant
+							else empty end
+						]
+						| if $version | startswith("1.7.") then
+							# backwards compatible "c8dind" tags for 1.7
+							. += map(
+								. + "-c8dind"
+								| sub("^latest-"; "")
+							)
+						else . end
+					),
+					Architectures: (.arches | join(", ")),
+					File: ("Dockerfile" + if $variant != "" then "." + $variant else "" end),
+				}
+			)
+			| reduce .[] as $e ([];
+				[ .[].Tags[] ] as $tags
+				| . += [ $e | .Tags -= $tags ]
+			)
+			| .[]
+			| .Tags |= join(", ")
+		)
 	]
-	| intersection
-	| join(", ")
-' "$dir/versions.json")"
-[ -n "$arches" ]
-
-source gsl-libs.sh
-
-globalEntry
-echo "Architectures: $arches"
-
-versionedTagsEntry "$dir" "$version" latest
-
-dockerfile='Dockerfile.c8dind' versionedVariantEntry "$dir" c8dind "$version" c8dind
+	| .[0].File as $globalFile
+	| map(
+		if .File == "Dockerfile" and ($globalFile | not) then
+			del(.File)
+		else . end
+		| to_entries
+		| map(.key + ": " + .value)
+		| join("\n")
+	)
+	| join("\n\n")
+' "$dir/versions.json"

--- a/containerd/versions.json
+++ b/containerd/versions.json
@@ -35,6 +35,82 @@
       "dpkgArch": null
     }
   },
+  "variants": [
+    "",
+    "rc",
+    "1.6"
+  ],
+  "rc": {
+    "commit": "27de5fea738a38345aa1ac7569032261a6b1e562",
+    "ref": "refs/tags/v2.0.0-rc.3^{}",
+    "tag": "v2.0.0-rc.3",
+    "version": "2.0.0-rc.3",
+    "arches": {
+      "amd64": {
+        "url": "https://github.com/containerd/containerd/releases/download/v2.0.0-rc.3/containerd-2.0.0-rc.3-linux-amd64.tar.gz",
+        "sha256": "467e38c95c7d06cb22226d8dd8acbda1be9ff785266b626886433fe96dfcddfd",
+        "dpkgArch": "amd64"
+      },
+      "arm64v8": {
+        "url": "https://github.com/containerd/containerd/releases/download/v2.0.0-rc.3/containerd-2.0.0-rc.3-linux-arm64.tar.gz",
+        "sha256": "c351fe80f8da958f548a097a7c16a23df3a2939ea1fee0df7c02f6671d999939",
+        "dpkgArch": "arm64"
+      },
+      "ppc64le": {
+        "url": "https://github.com/containerd/containerd/releases/download/v2.0.0-rc.3/containerd-2.0.0-rc.3-linux-ppc64le.tar.gz",
+        "sha256": "96b3283829af68f2e1695663f8578f59022cbe3066091f2b9a90182949cc8313",
+        "dpkgArch": "ppc64el"
+      },
+      "riscv64": {
+        "url": "https://github.com/containerd/containerd/releases/download/v2.0.0-rc.3/containerd-2.0.0-rc.3-linux-riscv64.tar.gz",
+        "sha256": "4388487c199956e7343952f157461d01e5810bbf3f2d01a77df43b38029960e3",
+        "dpkgArch": "riscv64"
+      },
+      "s390x": {
+        "url": "https://github.com/containerd/containerd/releases/download/v2.0.0-rc.3/containerd-2.0.0-rc.3-linux-s390x.tar.gz",
+        "sha256": "be24f0f79c7c5e2a4aecee35facefaea6452359c0e94f4de771877fa3257802f",
+        "dpkgArch": "s390x"
+      },
+      "windows-amd64": {
+        "url": "https://github.com/containerd/containerd/releases/download/v2.0.0-rc.3/containerd-2.0.0-rc.3-windows-amd64.tar.gz",
+        "sha256": "265382e329feb1d485eec37ea6cbceb8c4668f508c67f2166203be1999f1e1a0",
+        "dpkgArch": null
+      }
+    }
+  },
+  "1.6": {
+    "commit": "d2d58213f83a351ca8f528a95fbd145f5654e957",
+    "ref": "refs/tags/v1.6.33^{}",
+    "tag": "v1.6.33",
+    "version": "1.6.33",
+    "arches": {
+      "amd64": {
+        "url": "https://github.com/containerd/containerd/releases/download/v1.6.33/containerd-1.6.33-linux-amd64.tar.gz",
+        "sha256": "a0c7daa50386dc3ca19cbeb83d6987d43bdd92c0bb0429d08be7f9be4f9c307a",
+        "dpkgArch": "amd64"
+      },
+      "arm64v8": {
+        "url": "https://github.com/containerd/containerd/releases/download/v1.6.33/containerd-1.6.33-linux-arm64.tar.gz",
+        "sha256": "432cf17fbc01ba4fc59b949210baa96865185b8eb3b3292eb7a00e2f6bde9fe9",
+        "dpkgArch": "arm64"
+      },
+      "ppc64le": {
+        "url": "https://github.com/containerd/containerd/releases/download/v1.6.33/containerd-1.6.33-linux-ppc64le.tar.gz",
+        "sha256": "0a77fba37290a40a7853dbd7e5a297288d3657f7e92cd7864bc7187189a0a370",
+        "dpkgArch": "ppc64el"
+      },
+      "riscv64": {
+        "url": "https://github.com/containerd/containerd/releases/download/v1.6.33/containerd-1.6.33-linux-riscv64.tar.gz",
+        "sha256": "881e0013780a3a8cefd1fac39dcba771ed267f8f908ca8b2d628e6593b1de88c",
+        "dpkgArch": "riscv64"
+      },
+      "windows-amd64": {
+        "url": "https://github.com/containerd/containerd/releases/download/v1.6.33/containerd-1.6.33-windows-amd64.tar.gz",
+        "sha256": "4aeb0130e4da2b684354c2f0728525cd5bfe92d5c4668a19b214ebe406df694b",
+        "dpkgArch": null
+      }
+    }
+  },
   "runc": {
     "commit": "58aa9203c123022138b22cf96540c284876a7910",
     "ref": "refs/tags/v1.1.13^{}",


### PR DESCRIPTION
Also, upgrade to Bookworm and improve entrypoint to attempt to automatically apply `dind` (thus removing the need for the explicit `c8dind` tags, but for now, maintaining those for 1.7 for backwards compatibility).