### PR TITLE
Patch out BuildKit's linting behavior

### DIFF
--- a/buildkit/Dockerfile
+++ b/buildkit/Dockerfile
@@ -14,6 +14,7 @@ COPY \
 	git-no-submodules.patch \
 	mips64le.patch \
 	noclip.patch \
+	nolint.patch \
 	/tmp/buildkit-patches/
 
 WORKDIR /app

--- a/buildkit/Dockerfile.rc
+++ b/buildkit/Dockerfile.rc
@@ -14,6 +14,7 @@ COPY \
 	git-no-submodules.patch \
 	mips64le.patch \
 	noclip.patch \
+	nolint.patch \
 	/tmp/buildkit-patches/
 
 WORKDIR /app

--- a/buildkit/Dockerfile.template
+++ b/buildkit/Dockerfile.template
@@ -25,6 +25,10 @@ COPY \
 	git-no-submodules.patch \
 	mips64le.patch \
 	noclip.patch \
+{{ # linting was introduced in 0.14+ slash dockerfile/1.8.0 -}}
+{{ if .version | startswith("0.13.") then "" else ( -}}
+	nolint.patch \
+{{ ) end -}}
 	/tmp/buildkit-patches/
 
 WORKDIR /app

--- a/buildkit/nolint.patch
+++ b/buildkit/nolint.patch
@@ -1,0 +1,28 @@
+Description: forcibly disable the linter in the dockerfile frontend (BUILDKIT_SYNTAX=tianon/buildkit)
+Author: Tianon Gravi <admwiggin@gmail.com>
+Forwarded: no; upstream included this linter and enabled it by default intentionally
+
+Ideally, this would be disabled in such a way that it was merely disabled-by-default and could be re-enabled at runtime (opt-in instead of opt-out), but the code is byzantine enough that I wasn't able to find a simple/clean way to accomplish that (and being able to do so does not appear to be a goal of upstream's implementation).
+
+Alternatively, it would be interesting to try and remove *all* the code (instead of just making it no-op quickly), but the binary size reduction from doing so would probably not be large enough to justify the added burden of maintaining a more complex patch.
+
+diff --git a/frontend/dockerfile/linter/linter.go b/frontend/dockerfile/linter/linter.go
+index da94cbc9e..6d07a9ba7 100644
+--- a/frontend/dockerfile/linter/linter.go
++++ b/frontend/dockerfile/linter/linter.go
+@@ -25,6 +25,7 @@ type Linter struct {
+ }
+ 
+ func New(config *Config) *Linter {
++	return nil // NO LINTING
+ 	toret := &Linter{
+ 		SkippedRules: map[string]struct{}{},
+ 		CalledRules:  []string{},
+@@ -39,6 +40,7 @@ func New(config *Config) *Linter {
+ }
+ 
+ func (lc *Linter) Run(rule LinterRuleI, location []parser.Range, txt ...string) {
++	return // NO LINTING
+ 	if lc == nil || lc.Warn == nil || lc.SkipAll || rule.IsDeprecated() {
+ 		return
+ 	}


### PR DESCRIPTION
This requires using `BUILDKIT_SYNTAX=tianon/buildkit` (or `# syntax=tianon/buildkit`), since the linting is a function of the frontend (not buildkitd).