### PR TITLE
Backport riscv64 seccomp profile fix to buildkit builds

### DIFF
--- a/buildkit/Dockerfile
+++ b/buildkit/Dockerfile
@@ -10,6 +10,7 @@ FROM --platform=$BUILDPLATFORM golang:1.21 AS build
 ENV BUILDKIT_VERSION 0.15.2
 
 COPY \
+	backport-moby-48455-fix-riscv64-seccomp.patch \
 	containerd-arm64-v8.patch \
 	git-no-submodules.patch \
 	mips64le-pre-0.16.patch \

--- a/buildkit/Dockerfile.0.13
+++ b/buildkit/Dockerfile.0.13
@@ -12,6 +12,7 @@ ENV BUILDKIT_VERSION 0.13.2
 COPY \
 	backport-5072-fetch-tags.patch \
 	backport-5096-fix-umask.patch \
+	backport-moby-48455-fix-riscv64-seccomp.patch \
 	containerd-arm64-v8-pre-0.15.patch \
 	git-no-submodules.patch \
 	mips64le-pre-0.16.patch \

--- a/buildkit/Dockerfile.rc
+++ b/buildkit/Dockerfile.rc
@@ -10,6 +10,7 @@ FROM --platform=$BUILDPLATFORM golang:1.21 AS build
 ENV BUILDKIT_VERSION 0.16.0-rc1
 
 COPY \
+	backport-moby-48455-fix-riscv64-seccomp.patch \
 	containerd-arm64-v8.patch \
 	git-no-submodules.patch \
 	mips64le.patch \

--- a/buildkit/Dockerfile.template
+++ b/buildkit/Dockerfile.template
@@ -17,6 +17,7 @@ COPY \
 	backport-5072-fetch-tags.patch \
 	backport-5096-fix-umask.patch \
 {{) else "" end -}}
+	backport-moby-48455-fix-riscv64-seccomp.patch \
 {{ if .version | startswith("0.13.") or startswith("0.14.") then ( -}}
 	containerd-arm64-v8-pre-0.15.patch \
 {{ ) else ( -}}

--- a/buildkit/backport-moby-48455-fix-riscv64-seccomp.patch
+++ b/buildkit/backport-moby-48455-fix-riscv64-seccomp.patch
@@ -1,0 +1,24 @@
+Subject: seccomp: add riscv64 mapping to seccomp_linux.go
+Author: George Adams <georgeadams1995@gmail.com>
+Forwarded: https://github.com/moby/moby/pull/48455
+
+diff --git a/vendor/github.com/docker/docker/profiles/seccomp/seccomp_linux.go b/vendor/github.com/docker/docker/profiles/seccomp/seccomp_linux.go
+index 4d8fed68c6a19..17ee350e274ae 100644
+--- a/vendor/github.com/docker/docker/profiles/seccomp/seccomp_linux.go
++++ b/vendor/github.com/docker/docker/profiles/seccomp/seccomp_linux.go
+@@ -39,6 +39,7 @@ var nativeToSeccomp = map[string]specs.Arch{
+ 	"ppc":         specs.ArchPPC,
+ 	"ppc64":       specs.ArchPPC64,
+ 	"ppc64le":     specs.ArchPPC64LE,
++	"riscv64":     specs.ArchRISCV64,
+ 	"s390":        specs.ArchS390,
+ 	"s390x":       specs.ArchS390X,
+ }
+@@ -57,6 +58,7 @@ var goToNative = map[string]string{
+ 	"ppc":         "ppc",
+ 	"ppc64":       "ppc64",
+ 	"ppc64le":     "ppc64le",
++	"riscv64":     "riscv64",
+ 	"s390":        "s390",
+ 	"s390x":       "s390x",
+ }


### PR DESCRIPTION
See https://github.com/moby/moby/pull/48455 (fix for https://github.com/moby/moby/issues/48454, as seen in https://github.com/docker-library/official-images/pull/17403#issuecomment-2308179080)

Validated explicitly (patched exactly like this) in https://github.com/moby/moby/pull/48455#pullrequestreview-2290960698 :metal: