### PR TITLE
Update tinygo to 0.34.0, go min 1.19, go max 1.23

### DIFF
--- a/tinygo/Dockerfile
+++ b/tinygo/Dockerfile
@@ -4,14 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM golang:1.19-bookworm
+FROM golang:1.23-bookworm
 
 # the .deb (as of 0.6.0) installs to /usr/local/tinygo but doesn't add "tinygo" to PATH
 ENV PATH /usr/local/tinygo/bin:$PATH
 # https://tinygo.org/getting-started/linux/
 
 # https://github.com/tinygo-org/tinygo/releases
-ENV TINYGO_VERSION 0.33.0
+ENV TINYGO_VERSION 0.34.0
 
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/tinygo/Dockerfile.template
+++ b/tinygo/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM golang:{{ .go.version }}-bookworm
+FROM golang:{{ .go.max.version }}-bookworm
 
 # the .deb (as of 0.6.0) installs to /usr/local/tinygo but doesn't add "tinygo" to PATH
 ENV PATH /usr/local/tinygo/bin:$PATH

--- a/tinygo/versions.json
+++ b/tinygo/versions.json
@@ -1,9 +1,14 @@
 {
-  "commit": "ef4f46f1d1550beb62324d750c496b2b4a7f76d0",
-  "ref": "refs/tags/v0.33.0",
-  "tag": "v0.33.0",
-  "version": "0.33.0",
+  "commit": "2a76ceb7dd5ea5a834ec470b724882564d9681b3",
+  "ref": "refs/tags/v0.34.0",
+  "tag": "v0.34.0",
+  "version": "0.34.0",
   "go": {
-    "version": "1.19"
+    "min": {
+      "version": "1.19"
+    },
+    "max": {
+      "version": "1.23"
+    }
   }
 }


### PR DESCRIPTION
Commit https://github.com/tinygo-org/tinygo/commit/ac5f84e3d7b837643507fbd2b5af44b81a61af2e upstream changed the way the Go versions are expressed in the code to be something that's more friendly to scraping, so this scrapes the full range of Go versions instead of just the minimum (and updates the template to use the maximum supported version).

Finally fixes #624 (FYI @J0WI :eyes: :heart:)