### PR TITLE
Backport BuildKit's `index.json`+`mediaType` fix

### DIFF
--- a/buildkit/Dockerfile.0.13
+++ b/buildkit/Dockerfile.0.13
@@ -10,6 +10,7 @@ FROM --platform=$BUILDPLATFORM golang:1.21 AS build
 ENV BUILDKIT_VERSION 0.13.2
 
 COPY \
+	backport-4727-index-mediaType.patch \
 	backport-5072-fetch-tags.patch \
 	backport-5096-fix-umask.patch \
 	backport-5372-sbom-args.patch \

--- a/buildkit/Dockerfile.template
+++ b/buildkit/Dockerfile.template
@@ -12,8 +12,12 @@ ENV BUILDKIT_COMMIT $BUILDKIT_COMMIT
 ENV BUILDKIT_VERSION {{ .version }}
 {{ ) end -}}
 
+{{ # TODO put patches into an object with versioning information so this can be easier to maintain (patch: ... versions: ... else: ... ?) -}}
 COPY \
-{{ if env.variant != "dev" and (.version | startswith("0.13.") or startswith("0.14.")) then ( -}}
+{{ if .version | startswith("0.13.") then ( -}}
+	backport-4727-index-mediaType.patch \
+{{ ) else "" end -}}
+{{ if .version | startswith("0.13.") or startswith("0.14.") then ( -}}
 	backport-5072-fetch-tags.patch \
 	backport-5096-fix-umask.patch \
 {{) else "" end -}}

--- a/buildkit/backport-4727-index-mediaType.patch
+++ b/buildkit/backport-4727-index-mediaType.patch
@@ -1,0 +1,59 @@
+Description: add "mediaType" to OCI index.json files
+Author: Talon Bowler <talon.bowler@docker.com>
+Origin: https://github.com/moby/buildkit/pull/4727 + https://github.com/containerd/containerd/pull/9867 (https://github.com/moby/buildkit/pull/4814)
+Applied-Upstream: 0.14+
+
+diff --git a/client/ociindex/ociindex.go b/client/ociindex/ociindex.go
+index 512a77a68e67..5321f773d70e 100644
+--- a/client/ociindex/ociindex.go
++++ b/client/ociindex/ociindex.go
+@@ -102,6 +102,7 @@ func (s StoreIndex) Put(tag string, desc ocispecs.Descriptor) error {
+ 		}
+ 	}
+ 
++	setOCIIndexDefaults(&idx)
+ 	if err = insertDesc(&idx, desc, tag); err != nil {
+ 		return err
+ 	}
+@@ -145,6 +146,19 @@ func (s StoreIndex) GetSingle() (*ocispecs.Descriptor, error) {
+ 	return nil, nil
+ }
+ 
++// setOCIIndexDefaults updates zero values in index to their default values.
++func setOCIIndexDefaults(index *ocispecs.Index) {
++	if index == nil {
++		return
++	}
++	if index.SchemaVersion == 0 {
++		index.SchemaVersion = 2
++	}
++	if index.MediaType == "" {
++		index.MediaType = ocispecs.MediaTypeImageIndex
++	}
++}
++
+ // insertDesc puts desc to index with tag.
+ // Existing manifests with the same tag will be removed from the index.
+ func insertDesc(index *ocispecs.Index, desc ocispecs.Descriptor, tag string) error {
+@@ -152,9 +166,6 @@ func insertDesc(index *ocispecs.Index, desc ocispecs.Descriptor, tag string) err
+ 		return nil
+ 	}
+ 
+-	if index.SchemaVersion == 0 {
+-		index.SchemaVersion = 2
+-	}
+ 	if tag != "" {
+ 		if desc.Annotations == nil {
+ 			desc.Annotations = make(map[string]string)
+diff --git a/vendor/github.com/containerd/containerd/images/archive/exporter.go b/vendor/github.com/containerd/containerd/images/archive/exporter.go
+index 1f17a3cdbfec..8513e9a8bf0f 100644
+--- a/vendor/github.com/containerd/containerd/images/archive/exporter.go
++++ b/vendor/github.com/containerd/containerd/images/archive/exporter.go
+@@ -471,6 +471,7 @@ func ociIndexRecord(manifests []ocispec.Descriptor) tarRecord {
+ 		Versioned: ocispecs.Versioned{
+ 			SchemaVersion: 2,
+ 		},
++		MediaType: ocispec.MediaTypeImageIndex,
+ 		Manifests: manifests,
+ 	}
+ 


### PR DESCRIPTION
This makes sure that OCI outputs include `mediaType` in their `index.json` (both in tar mode and in directory mode).

See:
- https://github.com/moby/buildkit/issues/4595
- https://github.com/containerd/containerd/pull/9867  
  (+ https://github.com/moby/buildkit/pull/4814)
- https://github.com/moby/buildkit/pull/4727