### PR TITLE
Apply BuildKit patch to remove `ArgsEscaped` from built images

### DIFF
--- a/buildkit/Dockerfile
+++ b/buildkit/Dockerfile
@@ -10,6 +10,7 @@ FROM --platform=$BUILDPLATFORM golang:1.22 AS build
 ENV BUILDKIT_VERSION 0.17.1
 
 COPY \
+	argsescaped.patch \
 	containerd-arm64-v8.patch \
 	git-no-submodules.patch \
 	mips64le.patch \

--- a/buildkit/Dockerfile.0.13
+++ b/buildkit/Dockerfile.0.13
@@ -10,6 +10,7 @@ FROM --platform=$BUILDPLATFORM golang:1.21 AS build
 ENV BUILDKIT_VERSION 0.13.2
 
 COPY \
+	argsescaped-0.13.patch \
 	backport-4727-index-mediaType.patch \
 	backport-5072-fetch-tags.patch \
 	backport-5096-fix-umask.patch \

--- a/buildkit/Dockerfile.0.16
+++ b/buildkit/Dockerfile.0.16
@@ -10,6 +10,7 @@ FROM --platform=$BUILDPLATFORM golang:1.21 AS build
 ENV BUILDKIT_VERSION 0.16.0
 
 COPY \
+	argsescaped.patch \
 	backport-5372-sbom-args.patch \
 	backport-5441-fetch-by-commit.patch \
 	backport-moby-48455-fix-riscv64-seccomp.patch \

--- a/buildkit/Dockerfile.rc
+++ b/buildkit/Dockerfile.rc
@@ -10,6 +10,7 @@ FROM --platform=$BUILDPLATFORM golang:1.22 AS build
 ENV BUILDKIT_VERSION 0.17.0-rc2
 
 COPY \
+	argsescaped.patch \
 	containerd-arm64-v8.patch \
 	git-no-submodules.patch \
 	mips64le.patch \

--- a/buildkit/Dockerfile.template
+++ b/buildkit/Dockerfile.template
@@ -24,6 +24,7 @@ COPY \
 
 		# all patches should also adhere to Debian's DEP3 guidelines: https://dep-team.pages.debian.net/deps/dep3/
 
+		"argsescaped.patch": { older: { "0.16": "argsescaped-0.13.patch" } },
 		"backport-4727-index-mediaType.patch": { until: "0.14" },
 		"backport-5072-fetch-tags.patch": { until: "0.15" },
 		"backport-5096-fix-umask.patch": { until: "0.15" },

--- a/buildkit/argsescaped-0.13.patch
+++ b/buildkit/argsescaped-0.13.patch
@@ -1,0 +1,17 @@
+Description: do not set ArgsEscaped (on Linux)
+Author: Tianon Gravi <tianon@debian.org>
+Forwarded: https://github.com/moby/buildkit/pull/4723
+
+diff --git a/frontend/dockerfile/dockerfile2llb/convert.go b/frontend/dockerfile/dockerfile2llb/convert.go
+index 403530a74..ccd6c105a 100644
+--- a/frontend/dockerfile/dockerfile2llb/convert.go
++++ b/frontend/dockerfile/dockerfile2llb/convert.go
+@@ -1399,7 +1399,7 @@ func dispatchCmd(d *dispatchState, c *instructions.CmdCommand) error {
+ 		args = withShell(d.image, args)
+ 	}
+ 	d.image.Config.Cmd = args
+-	d.image.Config.ArgsEscaped = true //nolint:staticcheck // ignore SA1019: field is deprecated in OCI Image spec, but used for backward-compatibility with Docker image spec.
++	// TODO set ArgsEscaped appropriately *ONLY FOR WINDOWS* (it should never ever be set for Linux)
+ 	d.cmdSet = true
+ 	return commitToHistory(&d.image, fmt.Sprintf("CMD %q", args), false, nil, d.epoch)
+ }

--- a/buildkit/argsescaped.patch
+++ b/buildkit/argsescaped.patch
@@ -1,0 +1,17 @@
+Description: do not set ArgsEscaped (on Linux)
+Author: Tianon Gravi <tianon@debian.org>
+Forwarded: https://github.com/moby/buildkit/pull/4723
+
+diff --git a/frontend/dockerfile/dockerfile2llb/convert.go b/frontend/dockerfile/dockerfile2llb/convert.go
+index dbde75531..1e8ec165d 100644
+--- a/frontend/dockerfile/dockerfile2llb/convert.go
++++ b/frontend/dockerfile/dockerfile2llb/convert.go
+@@ -1662,7 +1662,7 @@ func dispatchCmd(d *dispatchState, c *instructions.CmdCommand, lint *linter.Lint
+ 		args = withShell(d.image, args)
+ 	}
+ 	d.image.Config.Cmd = args
+-	d.image.Config.ArgsEscaped = true //nolint:staticcheck // ignore SA1019: field is deprecated in OCI Image spec, but used for backward-compatibility with Docker image spec.
++	// TODO set ArgsEscaped appropriately *ONLY FOR WINDOWS* (it should never ever be set for Linux)
+ 	return commitToHistory(&d.image, fmt.Sprintf("CMD %q", args), false, nil, d.epoch)
+ }
+ 


### PR DESCRIPTION
The `ArgsEscaped` value should *never* be set for Linux images.

(see also https://github.com/moby/buildkit/pull/4723, which is hung up precisely because when I dug into this, I got caught up on wanting/trying to do the _right_ thing for Windows, which is complicated and requires re-working some BuildKit interfaces/abstractions :upside_down_face:)