### PR TITLE
Update Slack to Debian Trixie

### DIFF
--- a/slack/Dockerfile
+++ b/slack/Dockerfile
@@ -4,16 +4,15 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
+	apt-get install --update -y --no-install-recommends \
 		ca-certificates \
 # used as a fake browser so clicked URLs (and internal Slack behavior that wants to open a browser) pop up with a URL + clipboard instead of silently doing nothing
 		zenity xclip \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get dist-clean
 
 ENV LANG C.UTF-8
 
@@ -28,30 +27,28 @@ ENV SLACK_GPG_KEY DB085A08CA13B8ACB917E0F6D938EC0D038651BD
 RUN set -eux; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
+	apt-get install --update -y --no-install-recommends \
 		gnupg \
 	; \
-	rm -rf /var/lib/apt/lists; \
 	\
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$SLACK_GPG_KEY"; \
-	gpg --batch --export --armor "$SLACK_GPG_KEY" > /etc/apt/trusted.gpg.d/slack.gpg.asc; \
+	gpg --batch --export --armor "$SLACK_GPG_KEY" > /etc/apt/keyrings/slack.asc; \
 	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
-	apt-key list; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
-	echo 'deb https://packagecloud.io/slacktechnologies/slack/debian jessie main' > /etc/apt/sources.list.d/slack.list
+	echo 'deb [ signed-by=/etc/apt/keyrings/slack.asc ] https://packagecloud.io/slacktechnologies/slack/debian jessie main' > /etc/apt/sources.list.d/slack.list; \
+	apt-get update; \
+	apt-get dist-clean
 
 ENV SLACK_VERSION 4.47.69
 
 RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
+	apt-get install --update -y --no-install-recommends \
 		slack-desktop="$SLACK_VERSION" \
 # 3.0.2: slack: error while loading shared libraries: libX11-xcb.so.1: cannot open shared object file: No such file or directory
 		libx11-xcb1 \
@@ -64,10 +61,10 @@ RUN set -eux; \
 # 4.4.0: libGL error: failed to load driver: (i915_dri.so, i194, i965, swrast_dir.so, swrast)
 		libgl1-mesa-dri \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
+	apt-get dist-clean; \
 	slack="$(command -v slack)"; \
 	slack="$(readlink -ev "$slack")"; \
-	! { ldd "$slack" | grep 'not found'; }
+	if ldd "$slack" | grep 'not found'; then exit 1; fi
 
 COPY browser.sh /usr/local/bin/
 ENV BROWSER /usr/local/bin/browser.sh

--- a/slack/Dockerfile.template
+++ b/slack/Dockerfile.template
@@ -1,13 +1,12 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
+	apt-get install --update -y --no-install-recommends \
 		ca-certificates \
 # used as a fake browser so clicked URLs (and internal Slack behavior that wants to open a browser) pop up with a URL + clipboard instead of silently doing nothing
 		zenity xclip \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get dist-clean
 
 ENV LANG C.UTF-8
 
@@ -22,30 +21,28 @@ ENV SLACK_GPG_KEY DB085A08CA13B8ACB917E0F6D938EC0D038651BD
 RUN set -eux; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
+	apt-get install --update -y --no-install-recommends \
 		gnupg \
 	; \
-	rm -rf /var/lib/apt/lists; \
 	\
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$SLACK_GPG_KEY"; \
-	gpg --batch --export --armor "$SLACK_GPG_KEY" > /etc/apt/trusted.gpg.d/slack.gpg.asc; \
+	gpg --batch --export --armor "$SLACK_GPG_KEY" > /etc/apt/keyrings/slack.asc; \
 	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
-	apt-key list; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
-	echo 'deb https://packagecloud.io/slacktechnologies/slack/debian jessie main' > /etc/apt/sources.list.d/slack.list
+	echo 'deb [ signed-by=/etc/apt/keyrings/slack.asc ] https://packagecloud.io/slacktechnologies/slack/debian jessie main' > /etc/apt/sources.list.d/slack.list; \
+	apt-get update; \
+	apt-get dist-clean
 
 ENV SLACK_VERSION {{ .version }}
 
 RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
+	apt-get install --update -y --no-install-recommends \
 		slack-desktop="$SLACK_VERSION" \
 # 3.0.2: slack: error while loading shared libraries: libX11-xcb.so.1: cannot open shared object file: No such file or directory
 		libx11-xcb1 \
@@ -58,10 +55,10 @@ RUN set -eux; \
 # 4.4.0: libGL error: failed to load driver: (i915_dri.so, i194, i965, swrast_dir.so, swrast)
 		libgl1-mesa-dri \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
+	apt-get dist-clean; \
 	slack="$(command -v slack)"; \
 	slack="$(readlink -ev "$slack")"; \
-	! { ldd "$slack" | grep 'not found'; }
+	if ldd "$slack" | grep 'not found'; then exit 1; fi
 
 COPY browser.sh /usr/local/bin/
 ENV BROWSER /usr/local/bin/browser.sh


### PR DESCRIPTION
This is a follow-up to https://github.com/tianon/dockerfiles/pull/1069

(see https://github.com/tianon/dockerfiles/pull/1069#issuecomment-3182479028 in particular)

```console
+ apt-get update
Get:1 http://deb.debian.org/debian trixie InRelease [138 kB]
Get:2 http://deb.debian.org/debian trixie-updates InRelease [47.1 kB]
Get:3 http://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
Get:4 http://deb.debian.org/debian trixie/main amd64 Packages [9668 kB]
Get:5 http://deb.debian.org/debian trixie-updates/main amd64 Packages [2432 B]
Get:6 http://deb.debian.org/debian-security trixie-security/main amd64 Packages [5304 B]
Get:7 https://packagecloud.io/slacktechnologies/slack/debian jessie InRelease [29.1 kB]
Err:7 https://packagecloud.io/slacktechnologies/slack/debian jessie InRelease
  Sub-process /usr/bin/sqv returned an error code (1), error message is: Signing key on DB085A08CA13B8ACB917E0F6D938EC0D038651BD is not bound:            primary key   because: No binding signature at time 2025-07-24T20:19:54Z   because: Policy rejected non-revocation signature (PositiveCertification) requiring collision resistance   because: SHA1 is not considered secure since 2013-02-01T00:00:00Z
Reading package lists...
W: OpenPGP signature verification failed: https://packagecloud.io/slacktechnologies/slack/debian jessie InRelease: Sub-process /usr/bin/sqv returned an error code (1), error message is: Signing key on DB085A08CA13B8ACB917E0F6D938EC0D038651BD is not bound:            primary key   because: No binding signature at time 2025-07-24T20:19:54Z   because: Policy rejected non-revocation signature (PositiveCertification) requiring collision resistance   because: SHA1 is not considered secure since 2013-02-01T00:00:00Z
E: The repository 'https://packagecloud.io/slacktechnologies/slack/debian jessie InRelease' is not signed.
```

`W: OpenPGP signature verification failed: https://packagecloud.io/slacktechnologies/slack/debian jessie InRelease: Sub-process /usr/bin/sqv returned an error code (1), error message is: Signing key on DB085A08CA13B8ACB917E0F6D938EC0D038651BD is not bound:            primary key   because: No binding signature at time 2025-07-24T20:19:54Z   because: Policy rejected non-revocation signature (PositiveCertification) requiring collision resistance   because: SHA1 is not considered secure since 2013-02-01T00:00:00Z`