### PR TITLE
Update buildkit to rc 0.24.0-rc2

### DIFF
--- a/buildkit/Dockerfile
+++ b/buildkit/Dockerfile
@@ -12,7 +12,7 @@ ENV BUILDKIT_VERSION 0.23.2
 COPY \
 	argsescaped.patch \
 	containerd-arm64-v8.patch \
-	git-no-submodules.patch \
+	git-no-submodules-pre-0.24.patch \
 	mips64le.patch \
 	noclip.patch \
 	nolint.patch \

--- a/buildkit/Dockerfile.rc
+++ b/buildkit/Dockerfile.rc
@@ -7,7 +7,7 @@
 FROM --platform=$BUILDPLATFORM golang:1.23 AS build
 
 # https://github.com/moby/buildkit/releases
-ENV BUILDKIT_VERSION 0.24.0-rc1
+ENV BUILDKIT_VERSION 0.24.0-rc2
 
 COPY \
 	argsescaped.patch \

--- a/buildkit/Dockerfile.template
+++ b/buildkit/Dockerfile.template
@@ -32,7 +32,7 @@ COPY \
 		"backport-5441-fetch-by-commit.patch": { until: "0.17", older: { "0.16": "backport-5441-fetch-by-commit-0.13.patch" } },
 		"backport-moby-48455-fix-riscv64-seccomp.patch": { until: "0.17" },
 		"containerd-arm64-v8.patch": { older: { "0.19": "containerd-arm64-v8-pre-0.19.patch", "0.15": "containerd-arm64-v8-pre-0.15.patch" } },
-		"git-no-submodules.patch": { older: { "0.21": "git-no-submodules-pre-0.21.patch" } },
+		"git-no-submodules.patch": { older: { "0.24": "git-no-submodules-pre-0.24.patch", "0.21": "git-no-submodules-pre-0.21.patch" } },
 		"mips64le.patch": { older: { "0.16": "mips64le-pre-0.16.patch" } },
 		"noclip.patch": { },
 		"nolint.patch": { after: "0.14" }, # linting was introduced in 0.14+ slash dockerfile/1.8.0

--- a/buildkit/git-no-submodules-pre-0.24.patch
+++ b/buildkit/git-no-submodules-pre-0.24.patch
@@ -1,0 +1,20 @@
+Description: disable recursive cloning of submodules given a Git URL
+Forwarded: https://github.com/moby/buildkit/issues/4974, https://github.com/moby/moby/pull/3463#issuecomment-31778263
+
+diff --git a/source/git/source.go b/source/git/source.go
+index d139942fc..a3e251e41 100644
+--- a/source/git/source.go
++++ b/source/git/source.go
+@@ -619,12 +619,6 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out
+ 		}
+ 	}
+ 
+-	git = git.New(gitutil.WithWorkTree(checkoutDir), gitutil.WithGitDir(gitDir))
+-	_, err = git.Run(ctx, "submodule", "update", "--init", "--recursive", "--depth=1")
+-	if err != nil {
+-		return nil, errors.Wrapf(err, "failed to update submodules for %s", urlutil.RedactCredentials(gs.src.Remote))
+-	}
+-
+ 	if idmap := mount.IdentityMapping(); idmap != nil {
+ 		uid, gid := idmap.RootPair()
+ 		err := filepath.WalkDir(gitDir, func(p string, _ os.DirEntry, _ error) error {

--- a/buildkit/git-no-submodules.patch
+++ b/buildkit/git-no-submodules.patch
@@ -1,20 +1,29 @@
-Description: disable recursive cloning of submodules given a Git URL
-Forwarded: https://github.com/moby/buildkit/issues/4974, https://github.com/moby/moby/pull/3463#issuecomment-31778263
+Description: disable recursive cloning of submodules by default
+Forwarded: no (upstream's default makes sense for them)
 
-diff --git a/source/git/source.go b/source/git/source.go
-index d139942fc..a3e251e41 100644
---- a/source/git/source.go
-+++ b/source/git/source.go
-@@ -619,12 +619,6 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out
- 		}
+diff --git a/frontend/dockerfile/dockerfile2llb/convert.go b/frontend/dockerfile/dockerfile2llb/convert.go
+index 665bdb399..271ef0852 100644
+--- a/frontend/dockerfile/dockerfile2llb/convert.go
++++ b/frontend/dockerfile/dockerfile2llb/convert.go
+@@ -1545,7 +1545,7 @@ func dispatchCopy(d *dispatchState, cfg copyConfig) error {
+ 			if gitRef.SubDir != "" {
+ 				gitOptions = append(gitOptions, llb.GitSubDir(gitRef.SubDir))
+ 			}
+-			if gitRef.Submodules != nil && !*gitRef.Submodules {
++			if gitRef.Submodules == nil || !*gitRef.Submodules {
+ 				gitOptions = append(gitOptions, llb.GitSkipSubmodules())
+ 			}
+ 
+diff --git a/frontend/dockerui/context.go b/frontend/dockerui/context.go
+index 88d68569b..19a3a0b88 100644
+--- a/frontend/dockerui/context.go
++++ b/frontend/dockerui/context.go
+@@ -164,7 +164,7 @@ func DetectGitContext(ref string, keepGit *bool) (*llb.State, bool, error) {
+ 	if g.Checksum != "" {
+ 		gitOpts = append(gitOpts, llb.GitChecksum(g.Checksum))
+ 	}
+-	if g.Submodules != nil && !*g.Submodules {
++	if g.Submodules == nil || !*g.Submodules {
+ 		gitOpts = append(gitOpts, llb.GitSkipSubmodules())
  	}
  
--	git = git.New(gitutil.WithWorkTree(checkoutDir), gitutil.WithGitDir(gitDir))
--	_, err = git.Run(ctx, "submodule", "update", "--init", "--recursive", "--depth=1")
--	if err != nil {
--		return nil, errors.Wrapf(err, "failed to update submodules for %s", urlutil.RedactCredentials(gs.src.Remote))
--	}
--
- 	if idmap := mount.IdentityMapping(); idmap != nil {
- 		uid, gid := idmap.RootPair()
- 		err := filepath.WalkDir(gitDir, func(p string, _ os.DirEntry, _ error) error {

--- a/buildkit/versions.json
+++ b/buildkit/versions.json
@@ -13,10 +13,10 @@
     "0.13"
   ],
   "rc": {
-    "commit": "070d993324ee4f90c0517ca70229dcffa37c270a",
-    "ref": "refs/tags/v0.24.0-rc1",
-    "tag": "v0.24.0-rc1",
-    "version": "0.24.0-rc1",
+    "commit": "7ff02fb310bdc65a120e5cf946362727e3e3af84",
+    "ref": "refs/tags/v0.24.0-rc2",
+    "tag": "v0.24.0-rc2",
+    "version": "0.24.0-rc2",
     "go": {
       "version": "1.23"
     }


### PR DESCRIPTION
Including a new/refreshed patch for disabling submodules by default.